### PR TITLE
TextEditor Class and Line Functionality

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/abcdatalog/gui/DatalogGui.java
+++ b/src/main/java/edu/harvard/seas/pl/abcdatalog/gui/DatalogGui.java
@@ -97,7 +97,8 @@ import edu.harvard.seas.pl.abcdatalog.parser.DatalogTokenizer;
  */
 @SuppressWarnings("serial")
 public class DatalogGui extends JFrame {
-	private final JTextArea program, results;
+	private final TextEditor program;
+	private final JTextArea results;
 	private final JTextField query;
 	private final Action queryAction;
 	private final JTextPane warning;
@@ -133,7 +134,7 @@ public class DatalogGui extends JFrame {
 		JLabel editorLabel = new JLabel("Program: ");
 		editorLabel.setAlignmentX(Component.LEFT_ALIGNMENT);
 		editorPanel.add(editorLabel, BorderLayout.NORTH);
-		this.program = new JTextArea(20, 60);
+		this.program = new TextEditor(20, 60);
 		this.program.setFont(new Font(Font.DIALOG, Font.PLAIN, this.defaultFontSize));
 		this.program.setLineWrap(true);
 		this.program.setWrapStyleWord(true);
@@ -293,6 +294,36 @@ public class DatalogGui extends JFrame {
 				KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
 				e -> program.setText("")
 		);
+		JMenuItem deleteLineMenuItem = createMenuItem(
+				"Delete line",
+				'd',
+				KeyStroke.getKeyStroke(KeyEvent.VK_D, KeyEvent.CTRL_DOWN_MASK),
+				e -> program.deleteCurrentLine()
+		);
+		JMenuItem duplicateLineMenuItem = createMenuItem(
+				"Duplicate line",
+				'l',
+				KeyStroke.getKeyStroke(KeyEvent.VK_D, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
+				e -> program.duplicateCurrentLine()
+		);
+		JMenuItem moveLineUpMenuItem = createMenuItem(
+				"Move line up",
+				'm',
+				KeyStroke.getKeyStroke(KeyEvent.VK_UP, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
+				e -> program.moveLine(-1)
+		);
+		JMenuItem moveLineDownMenuItem = createMenuItem(
+				"Move line down",
+				'e',
+				KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, KeyEvent.CTRL_DOWN_MASK | KeyEvent.SHIFT_DOWN_MASK),
+				e -> program.moveLine(1)
+		);
+		JMenuItem toggleLineComment = createMenuItem(
+				"Toggle comment",
+				't',
+				KeyStroke.getKeyStroke(KeyEvent.VK_SLASH, KeyEvent.CTRL_DOWN_MASK),
+				e -> program.toggleComment()
+		);
 		JMenuItem zoomInMenuItem = createMenuItem(
 				"Zoom in",
 				'i',
@@ -330,6 +361,12 @@ public class DatalogGui extends JFrame {
 		editMenu.addSeparator();
 		editMenu.add(selectAllMenuItem);
 		editMenu.add(clearAllMenuItem);
+		editMenu.addSeparator();
+		editMenu.add(deleteLineMenuItem);
+		editMenu.add(duplicateLineMenuItem);
+		editMenu.add(moveLineUpMenuItem);
+		editMenu.add(moveLineDownMenuItem);
+		editMenu.add(toggleLineComment);
 		viewMenu.add(zoomInMenuItem);
 		viewMenu.add(zoomOutMenuItem);
 		viewMenu.add(restoreZoomMenuItem);

--- a/src/main/java/edu/harvard/seas/pl/abcdatalog/gui/TextEditor.java
+++ b/src/main/java/edu/harvard/seas/pl/abcdatalog/gui/TextEditor.java
@@ -1,0 +1,168 @@
+package edu.harvard.seas.pl.abcdatalog.gui;
+
+import javax.swing.JTextArea;
+import javax.swing.text.BadLocationException;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+
+public class TextEditor extends JTextArea {
+    TextEditor(int rows, int columns) {
+        this.setRows(rows);
+        this.setColumns(columns);
+        this.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyTyped(KeyEvent e) {
+                char c = e.getKeyChar();
+                if (c == '(') {
+                    autocompleteParentheses();
+                    e.consume();
+                }
+            }
+        });
+    }
+
+    /**
+     * Is called when ( key is typed. Either inserts () with
+     * caret in the middle or encloses text with parentheses
+     * if there is any selected text.
+     */
+    private void autocompleteParentheses() {
+        String selectedText = this.getSelectedText();
+        if (selectedText != null && !selectedText.isEmpty()) {
+            int start = this.getSelectionStart();
+            int end = this.getSelectionEnd();
+            String newText = '(' + selectedText + ')';
+            this.replaceSelection(newText);
+            this.setSelectionStart(start);
+            this.setSelectionEnd(end + 2);
+        } else {
+            int pos = this.getCaretPosition();
+            this.insert("()", pos);
+            this.setCaretPosition(pos + 1);
+        }
+    }
+
+    /**
+     * Deletes the current line and if there is no
+     * text, sets the caret to the end of the previous line.
+     */
+    public void deleteCurrentLine() {
+        int pos = this.getCaretPosition();
+
+        try {
+            int lineNumber = this.getLineOfOffset(pos);
+            int start = this.getLineStartOffset(lineNumber);
+            int end = this.getLineEndOffset(lineNumber);
+            String currentLine = this.getText(start, end - start);
+            if (currentLine.trim().isEmpty() && lineNumber > 0) {
+                // Current line is empty, move caret to end of previous line
+                int prevLineEnd = this.getLineEndOffset(lineNumber - 1);
+                this.setCaretPosition(prevLineEnd - 1);
+            } else {
+                // Current line is not empty, delete it
+                this.replaceRange("", start, end);
+            }
+        } catch (BadLocationException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Duplicates the current line, moving the caret
+     * to the new line but keeping its position relative
+     * to that line.
+     */
+    public void duplicateCurrentLine() {
+        int pos = this.getCaretPosition();
+
+        try {
+            int lineNumber = this.getLineOfOffset(pos);
+            int start = this.getLineStartOffset(lineNumber);
+            int end = this.getLineEndOffset(lineNumber);
+            String currentLineText = this.getText(start, end - start);
+
+            boolean endsWithNewLine = currentLineText.endsWith(System.lineSeparator());
+
+            // Calculate the position of the new line
+            int newLineStart;
+            if (endsWithNewLine) {
+                newLineStart = end;
+            } else {
+                newLineStart = end + System.lineSeparator().length();
+                this.insert(System.lineSeparator(), end);
+            }
+
+            // Insert duplicate line
+            this.insert(currentLineText, newLineStart);
+
+            // Set the caret position to the same place relative to the current line
+            int relativeCaretPosition = pos - start;
+            this.setCaretPosition(newLineStart + relativeCaretPosition);
+        } catch (BadLocationException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Moves the current line up or down.
+     * @param direction
+     *                  Direction to move the line, where 1 = down and -1 = up.
+     */
+    public void moveLine(int direction) {
+        int pos = this.getCaretPosition();
+
+        try {
+            int lineNumber = this.getLineOfOffset(pos);
+            int lineCount = this.getLineCount();
+            if ((direction < 0 && lineNumber == 0) || (direction > 0 && lineNumber == lineCount - 1)) {
+                // Can't move first line up or last line down
+                return;
+            }
+
+            int start = this.getLineStartOffset(lineNumber);
+            int caretOffset = pos - start;
+
+            // Regex \\R matches any newline separator
+            String[] lines = this.getText().split("\\R");
+            String temp = lines[lineNumber];
+            lines[lineNumber] = lines[lineNumber + direction];
+            lines[lineNumber + direction] = temp;
+            this.setText(String.join(System.lineSeparator(), lines));
+
+            int newLineStart = this.getLineStartOffset(lineNumber + direction);
+            int newPos = newLineStart + caretOffset;
+            this.setCaretPosition(newPos);
+        } catch (BadLocationException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Inserts a comment and a space if there is none,
+     * or removes an existing comment character if there
+     * is one. Works best if comment character is
+     * followed by a space.
+     */
+    public void toggleComment() {
+        int pos = this.getCaretPosition();
+
+        try {
+            int lineNumber = this.getLineOfOffset(pos);
+            int start = this.getLineStartOffset(lineNumber);
+            int end = this.getLineEndOffset(lineNumber);
+            String currentLine = this.getText(start, end - start);
+
+            if (currentLine.trim().startsWith("% ")) {
+                // Line is already commented, remove the %
+                this.replaceRange(currentLine.replaceFirst("% ", ""), start, end);
+                this.setCaretPosition(pos - 2);
+            } else {
+                // Line is not commented, insert the %
+                this.insert("% ", start);
+                this.setCaretPosition(pos + 2);
+            }
+        } catch (BadLocationException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
To introduce the changes, I inherited from `JTextArea` to create a custom `TextEditor` class. This is optimal since it is better to separate text editing concerns from the main GUI. The functionality of the class includes:

- Autocompleting parenthesis (or enclosing selected text if there is any)
- Delete current line
- Duplicate current line
- Move current line up or down
- Toggle comment in current line

In the main GUI class, I have also added to the Edit menu items corresponding to each of these functionalities with accelerators and mnemonics of course.

**Note 1:** Exception handling in the `TextEditor` class is less than optimal. Wrapping the entire functionality in try/catch blocks
is not the greatest solution but there is nothing better that I can think of at this instant. I have tested all of these functions on multiple inputs and they should be stable. Things get even messier since a `try` introduces a new scope.

**Note 2:** Toggle line functionality works best if the line starts with `% comment...`. The space after the `%` is important,
but as long as it is there, toggling should work very well. Handling other cases would have been too much for a simple toggle function.

Resolves #2 