### PR TITLE
Refactor unit tests

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/bottomup/concurrent/ConcurrentChunkedBottomUpEngine.java
+++ b/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/bottomup/concurrent/ConcurrentChunkedBottomUpEngine.java
@@ -44,9 +44,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.BiConsumer;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-
 import edu.harvard.seas.pl.abcdatalog.ast.Clause;
 import edu.harvard.seas.pl.abcdatalog.ast.PositiveAtom;
 import edu.harvard.seas.pl.abcdatalog.ast.PredicateSym;
@@ -59,9 +56,6 @@ import edu.harvard.seas.pl.abcdatalog.engine.bottomup.ClauseEvaluator;
 import edu.harvard.seas.pl.abcdatalog.engine.bottomup.EvalManager;
 import edu.harvard.seas.pl.abcdatalog.engine.bottomup.SemiNaiveClauseAnnotator;
 import edu.harvard.seas.pl.abcdatalog.engine.bottomup.SemiNaiveClauseAnnotator.SemiNaiveClause;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.ConjunctiveQueryTests;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.CoreTests;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.ExplicitUnificationTests;
 import edu.harvard.seas.pl.abcdatalog.util.Box;
 import edu.harvard.seas.pl.abcdatalog.util.ExecutorServiceCounter;
 import edu.harvard.seas.pl.abcdatalog.util.Utilities;
@@ -79,11 +73,7 @@ import edu.harvard.seas.pl.abcdatalog.util.substitution.ConstOnlySubstitution;
  * bundled together during evaluation).
  *
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-	ConcurrentChunkedBottomUpEngine.MyCoreTests.class,
-	ConcurrentChunkedBottomUpEngine.MyUnificationTests.class,
-	})
+
 public class ConcurrentChunkedBottomUpEngine extends BottomUpEngineFrame<EvalManager> {
 
 	public ConcurrentChunkedBottomUpEngine(int chunkSize) {
@@ -208,31 +198,5 @@ public class ConcurrentChunkedBottomUpEngine extends BottomUpEngineFrame<EvalMan
 			}
 
 		}
-
 	}
-
-	public static class MyCoreTests extends CoreTests {
-
-		public MyCoreTests() {
-			super(() -> new ConcurrentChunkedBottomUpEngine(4));
-		}
-
-	}
-
-	public static class MyUnificationTests extends ExplicitUnificationTests {
-
-		public MyUnificationTests() {
-			super(() -> new ConcurrentChunkedBottomUpEngine(4));
-		}
-
-	}
-	
-	public static class MyConjunctiveQueryTests extends ConjunctiveQueryTests {
-
-		public MyConjunctiveQueryTests() {
-			super(() -> new ConcurrentChunkedBottomUpEngine(4));
-		}
-
-	}
-
 }

--- a/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/bottomup/concurrent/ConcurrentStratifiedNegationBottomUpEngine.java
+++ b/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/bottomup/concurrent/ConcurrentStratifiedNegationBottomUpEngine.java
@@ -33,63 +33,19 @@ package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
  * #L%
  */
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
 import edu.harvard.seas.pl.abcdatalog.engine.bottomup.BottomUpEngineFrame;
 import edu.harvard.seas.pl.abcdatalog.engine.bottomup.EvalManager;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.ConjunctiveQueryTests;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.CoreTests;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.ExplicitUnificationTests;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.StratifiedNegationTests;
 
 /**
  * This class implements an experimental multi-threaded Datalog evaluation
  * algorithm that supports explicit unification and stratified negation.
  *
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-	ConcurrentStratifiedNegationBottomUpEngine.MyCoreTests.class,
-	ConcurrentStratifiedNegationBottomUpEngine.MyUnificationTests.class,
-	ConcurrentStratifiedNegationBottomUpEngine.MyNegationTests.class
-})
+
 public class ConcurrentStratifiedNegationBottomUpEngine extends BottomUpEngineFrame<EvalManager> {
 
 	public ConcurrentStratifiedNegationBottomUpEngine() {
 		super(new StratifiedNegationEvalManager());
 	}
-
-	public static class MyCoreTests extends CoreTests {
-
-		public MyCoreTests() {
-			super(() -> new ConcurrentStratifiedNegationBottomUpEngine());
-		}
-
-	}
-
-	public static class MyUnificationTests extends ExplicitUnificationTests {
-
-		public MyUnificationTests() {
-			super(() -> new ConcurrentStratifiedNegationBottomUpEngine());
-		}
-
-	}
-
-	public static class MyNegationTests extends StratifiedNegationTests {
-
-		public MyNegationTests() {
-			super(() -> new ConcurrentStratifiedNegationBottomUpEngine());
-		}
-
-	}
-	
-	public static class MyConjunctiveQueryTests extends ConjunctiveQueryTests {
-
-		public MyConjunctiveQueryTests() {
-			super(() -> new ConcurrentStratifiedNegationBottomUpEngine());
-		}
-
-	}
-
 }

--- a/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/bottomup/sequential/SemiNaiveEngine.java
+++ b/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/bottomup/sequential/SemiNaiveEngine.java
@@ -37,19 +37,12 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.util.Set;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-
 import edu.harvard.seas.pl.abcdatalog.ast.Clause;
 import edu.harvard.seas.pl.abcdatalog.ast.PositiveAtom;
 import edu.harvard.seas.pl.abcdatalog.ast.Premise;
 import edu.harvard.seas.pl.abcdatalog.engine.DatalogEngine;
 import edu.harvard.seas.pl.abcdatalog.engine.DatalogEngineWithProvenance;
 import edu.harvard.seas.pl.abcdatalog.engine.bottomup.BottomUpEngineFrameWithProvenance;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.ConjunctiveQueryTests;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.CoreTests;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.ExplicitUnificationTests;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.StratifiedNegationTests;
 import edu.harvard.seas.pl.abcdatalog.parser.DatalogParser;
 import edu.harvard.seas.pl.abcdatalog.parser.DatalogTokenizer;
 
@@ -58,13 +51,7 @@ import edu.harvard.seas.pl.abcdatalog.parser.DatalogTokenizer;
  * algorithm. It supports explicit unification and stratified negation.
  *
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-	SemiNaiveEngine.MyCoreTests.class,
-	SemiNaiveEngine.MyUnificationTests.class,
-	SemiNaiveEngine.MyNegationTests.class,
-	SemiNaiveEngine.MyConjunctiveQueryTests.class
-})
+
 public class SemiNaiveEngine extends BottomUpEngineFrameWithProvenance {
 
 	public static DatalogEngine newEngine() {
@@ -75,40 +62,8 @@ public class SemiNaiveEngine extends BottomUpEngineFrameWithProvenance {
 		return new SemiNaiveEngine(true);
 	}
 	
-	SemiNaiveEngine(boolean collectProv) {
+	public SemiNaiveEngine(boolean collectProv) {
 		super(new SemiNaiveEvalManager(collectProv));
-	}
-
-	public static class MyCoreTests extends CoreTests {
-
-		public MyCoreTests() {
-			super(() -> new SemiNaiveEngine(true));
-		}
-
-	}
-
-	public static class MyUnificationTests extends ExplicitUnificationTests {
-
-		public MyUnificationTests() {
-			super(() -> new SemiNaiveEngine(true));
-		}
-
-	}
-
-	public static class MyNegationTests extends StratifiedNegationTests {
-
-		public MyNegationTests() {
-			super(() -> new SemiNaiveEngine(true));
-		}
-
-	}
-
-	public static class MyConjunctiveQueryTests extends ConjunctiveQueryTests {
-
-		public MyConjunctiveQueryTests() {
-			super(() -> new SemiNaiveEngine(true));
-		}
-
 	}
 
 	public static void main(String[] args) throws Exception {
@@ -143,5 +98,4 @@ public class SemiNaiveEngine extends BottomUpEngineFrameWithProvenance {
 			}
 		}
 	}
-
 }

--- a/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/topdown/IterativeQsqEngine.java
+++ b/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/topdown/IterativeQsqEngine.java
@@ -44,27 +44,18 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-
 import edu.harvard.seas.pl.abcdatalog.ast.Constant;
 import edu.harvard.seas.pl.abcdatalog.ast.PositiveAtom;
 import edu.harvard.seas.pl.abcdatalog.ast.Term;
 import edu.harvard.seas.pl.abcdatalog.ast.Variable;
 import edu.harvard.seas.pl.abcdatalog.ast.validation.DatalogValidator.ValidClause;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.ConjunctiveQueryTests;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.CoreTests;
 
 /**
  * A Datalog evaluation engine that uses an iterative version of the
  * query-subquery top-down technique.
  *
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-	IterativeQsqEngine.MyCoreTests.class,
-	IterativeQsqEngine.MyConjunctiveQueryTests.class
-})
+
 public class IterativeQsqEngine extends AbstractQsqEngine {
 
 	@Override
@@ -536,21 +527,4 @@ public class IterativeQsqEngine extends AbstractQsqEngine {
 			this.newInfo = newInfo;
 		}
 	}
-
-	public static class MyCoreTests extends CoreTests {
-
-		public MyCoreTests() {
-			super(() -> new IterativeQsqEngine());
-		}
-
-	}
-	
-	public static class MyConjunctiveQueryTests extends ConjunctiveQueryTests {
-
-		public MyConjunctiveQueryTests() {
-			super(() -> new IterativeQsqEngine());
-		}
-
-	}
-
 }

--- a/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/topdown/MstEngine.java
+++ b/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/topdown/MstEngine.java
@@ -42,9 +42,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-
 import edu.harvard.seas.pl.abcdatalog.ast.Clause;
 import edu.harvard.seas.pl.abcdatalog.ast.Constant;
 import edu.harvard.seas.pl.abcdatalog.ast.PositiveAtom;
@@ -53,13 +50,11 @@ import edu.harvard.seas.pl.abcdatalog.ast.Premise;
 import edu.harvard.seas.pl.abcdatalog.ast.Term;
 import edu.harvard.seas.pl.abcdatalog.ast.validation.DatalogValidationException;
 import edu.harvard.seas.pl.abcdatalog.ast.validation.DatalogValidator;
-import edu.harvard.seas.pl.abcdatalog.ast.validation.UnstratifiedProgram;
 import edu.harvard.seas.pl.abcdatalog.ast.validation.DatalogValidator.ValidClause;
+import edu.harvard.seas.pl.abcdatalog.ast.validation.UnstratifiedProgram;
 import edu.harvard.seas.pl.abcdatalog.ast.visitors.HeadVisitor;
 import edu.harvard.seas.pl.abcdatalog.engine.DatalogEngine;
 import edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent.ConcurrentBottomUpEngine;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.ConjunctiveQueryTests;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.CoreTests;
 import edu.harvard.seas.pl.abcdatalog.util.Utilities;
 
 /**
@@ -70,11 +65,7 @@ import edu.harvard.seas.pl.abcdatalog.util.Utilities;
  * <b>NOTE:</b> predicate symbols that use '%' might not work with this engine.
  *
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-	MstEngine.MyCoreTests.class,
-	MstEngine.MyConjunctiveQueryTests.class
-})
+
 public class MstEngine implements DatalogEngine {
 	// FIXME The predicate symbol issue noted in the Javadocs is awkward.
 	
@@ -450,21 +441,4 @@ public class MstEngine implements DatalogEngine {
 		PositiveAtom head = createInputAtom(headPred, headArgs);
 		return new Clause(head, body);
 	}
-
-	public static class MyCoreTests extends CoreTests {
-
-		public MyCoreTests() {
-			super(() -> new MstEngine());
-		}
-
-	}
-	
-	public static class MyConjunctiveQueryTests extends ConjunctiveQueryTests {
-
-		public MyConjunctiveQueryTests() {
-			super(() -> new MstEngine());
-		}
-
-	}
-
 }

--- a/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/topdown/RecursiveQsqEngine.java
+++ b/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/topdown/RecursiveQsqEngine.java
@@ -41,29 +41,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.runners.Suite;
-
 import edu.harvard.seas.pl.abcdatalog.ast.Constant;
 import edu.harvard.seas.pl.abcdatalog.ast.PositiveAtom;
 import edu.harvard.seas.pl.abcdatalog.ast.PredicateSym;
 import edu.harvard.seas.pl.abcdatalog.ast.Term;
 import edu.harvard.seas.pl.abcdatalog.ast.Variable;
 import edu.harvard.seas.pl.abcdatalog.ast.validation.DatalogValidator.ValidClause;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.ConjunctiveQueryTests;
-import edu.harvard.seas.pl.abcdatalog.engine.testing.CoreTests;
-
-import org.junit.runner.RunWith;
 
 /**
  * A Datalog evaluation engine that uses a recursive version of the
  * query-subquery top-down technique.
  *
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
-	RecursiveQsqEngine.MyCoreTests.class,
-	RecursiveQsqEngine.MyConjunctiveQueryTests.class
-})
+
 public class RecursiveQsqEngine extends AbstractQsqEngine {
 
 	/**
@@ -415,21 +405,4 @@ public class RecursiveQsqEngine extends AbstractQsqEngine {
 				sup.applyTuplesAsSubstitutions(new Tuple(rule.getHead().getArgs())));
 
 	}
-	
-	public static class MyCoreTests extends CoreTests {
-		
-		public MyCoreTests() {
-			super(() -> new RecursiveQsqEngine());
-		}
-		
-	}
-	
-	public static class MyConjunctiveQueryTests extends ConjunctiveQueryTests {
-
-		public MyConjunctiveQueryTests() {
-			super(() -> new RecursiveQsqEngine());
-		}
-
-	}
-
 }

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/AbstractTests.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/AbstractTests.java
@@ -1,4 +1,4 @@
-package edu.harvard.seas.pl.abcdatalog.engine.testing;
+package edu.harvard.seas.pl.abcdatalog.engine;
 
 /*-
  * #%L
@@ -48,7 +48,6 @@ import java.util.function.Supplier;
 import edu.harvard.seas.pl.abcdatalog.ast.Clause;
 import edu.harvard.seas.pl.abcdatalog.ast.PositiveAtom;
 import edu.harvard.seas.pl.abcdatalog.ast.validation.DatalogValidationException;
-import edu.harvard.seas.pl.abcdatalog.engine.DatalogEngine;
 import edu.harvard.seas.pl.abcdatalog.parser.DatalogParseException;
 import edu.harvard.seas.pl.abcdatalog.parser.DatalogParser;
 import edu.harvard.seas.pl.abcdatalog.parser.DatalogTokenizer;

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/ConcurrentBottomUpEngineTest.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/ConcurrentBottomUpEngineTest.java
@@ -1,4 +1,4 @@
-package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
+package edu.harvard.seas.pl.abcdatalog.engine;
 
 /*-
  * #%L
@@ -8,18 +8,18 @@ package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
  * %%
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the President and Fellows of Harvard College nor the names of its contributors
  *    may be used to endorse or promote products derived from this software without
  *    specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -33,19 +33,39 @@ package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
  * #L%
  */
 
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.BottomUpEngineFrame;
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.EvalManager;
+import edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent.ConcurrentBottomUpEngine;
 
-/**
- * A concurrent bottom-up Datalog engine that employs a saturation algorithm
- * similar to semi-naive evaluation. It supports explicit unification.
- *
- */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        ConcurrentBottomUpEngineTest.MyCoreTests.class,
+        ConcurrentBottomUpEngineTest.MyUnificationTests.class,
+        ConcurrentBottomUpEngineTest.MyConjunctiveQueryTests.class
+})
+public class ConcurrentBottomUpEngineTest {
+    public static class MyCoreTests extends CoreTests {
 
-public class ConcurrentBottomUpEngine extends BottomUpEngineFrame<EvalManager> {
+        public MyCoreTests() {
+            super(() -> new ConcurrentBottomUpEngine());
+        }
 
-	public ConcurrentBottomUpEngine() {
-		super(new BottomUpEvalManager());
-	}
+    }
+
+    public static class MyUnificationTests extends ExplicitUnificationTests {
+
+        public MyUnificationTests() {
+            super(() -> new ConcurrentBottomUpEngine());
+        }
+
+    }
+
+    public static class MyConjunctiveQueryTests extends ConjunctiveQueryTests {
+
+        public MyConjunctiveQueryTests() {
+            super(() -> new ConcurrentBottomUpEngine());
+        }
+
+    }
 }

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/ConcurrentChunkedBottomUpEngineTest.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/ConcurrentChunkedBottomUpEngineTest.java
@@ -1,4 +1,4 @@
-package edu.harvard.seas.pl.abcdatalog.engine.testing;
+package edu.harvard.seas.pl.abcdatalog.engine;
 
 /*-
  * #%L
@@ -8,18 +8,18 @@ package edu.harvard.seas.pl.abcdatalog.engine.testing;
  * %%
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the President and Fellows of Harvard College nor the names of its contributors
  *    may be used to endorse or promote products derived from this software without
  *    specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -36,28 +36,36 @@ package edu.harvard.seas.pl.abcdatalog.engine.testing;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent.ConcurrentBottomUpEngine;
 import edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent.ConcurrentChunkedBottomUpEngine;
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent.ConcurrentStratifiedNegationBottomUpEngine;
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.sequential.SemiNaiveEngine;
-import edu.harvard.seas.pl.abcdatalog.engine.topdown.IterativeQsqEngine;
-import edu.harvard.seas.pl.abcdatalog.engine.topdown.MstEngine;
-import edu.harvard.seas.pl.abcdatalog.engine.topdown.RecursiveQsqEngine;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-	ConcurrentBottomUpEngine.class,
-	ConcurrentChunkedBottomUpEngine.class,
-	ConcurrentStratifiedNegationBottomUpEngine.class,
-	SemiNaiveEngine.class,
-	RecursiveQsqEngine.class,
-	IterativeQsqEngine.class,
-	MstEngine.class
+        ConcurrentChunkedBottomUpEngineTest.MyCoreTests.class,
+        ConcurrentChunkedBottomUpEngineTest.MyUnificationTests.class,
 })
-public class RunAllTests {
+public class ConcurrentChunkedBottomUpEngineTest {
 
-	public RunAllTests() {
-		
-	}
+    public static class MyCoreTests extends CoreTests {
 
+        public MyCoreTests() {
+            super(() -> new ConcurrentChunkedBottomUpEngine(4));
+        }
+
+    }
+
+    public static class MyUnificationTests extends ExplicitUnificationTests {
+
+        public MyUnificationTests() {
+            super(() -> new ConcurrentChunkedBottomUpEngine(4));
+        }
+
+    }
+
+    public static class MyConjunctiveQueryTests extends ConjunctiveQueryTests {
+
+        public MyConjunctiveQueryTests() {
+            super(() -> new ConcurrentChunkedBottomUpEngine(4));
+        }
+
+    }
 }

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/ConcurrentStratifiedNegationBottomUpEngineTest.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/ConcurrentStratifiedNegationBottomUpEngineTest.java
@@ -1,4 +1,4 @@
-package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
+package edu.harvard.seas.pl.abcdatalog.engine;
 
 /*-
  * #%L
@@ -8,18 +8,18 @@ package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
  * %%
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the President and Fellows of Harvard College nor the names of its contributors
  *    may be used to endorse or promote products derived from this software without
  *    specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -33,19 +33,47 @@ package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
  * #L%
  */
 
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.BottomUpEngineFrame;
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.EvalManager;
+import edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent.ConcurrentStratifiedNegationBottomUpEngine;
 
-/**
- * A concurrent bottom-up Datalog engine that employs a saturation algorithm
- * similar to semi-naive evaluation. It supports explicit unification.
- *
- */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        ConcurrentStratifiedNegationBottomUpEngineTest.MyCoreTests.class,
+        ConcurrentStratifiedNegationBottomUpEngineTest.MyUnificationTests.class,
+        ConcurrentStratifiedNegationBottomUpEngineTest.MyNegationTests.class
+})
+public class ConcurrentStratifiedNegationBottomUpEngineTest {
+    public static class MyCoreTests extends CoreTests {
 
-public class ConcurrentBottomUpEngine extends BottomUpEngineFrame<EvalManager> {
+        public MyCoreTests() {
+            super(() -> new ConcurrentStratifiedNegationBottomUpEngine());
+        }
 
-	public ConcurrentBottomUpEngine() {
-		super(new BottomUpEvalManager());
-	}
+    }
+
+    public static class MyUnificationTests extends ExplicitUnificationTests {
+
+        public MyUnificationTests() {
+            super(() -> new ConcurrentStratifiedNegationBottomUpEngine());
+        }
+
+    }
+
+    public static class MyNegationTests extends StratifiedNegationTests {
+
+        public MyNegationTests() {
+            super(() -> new ConcurrentStratifiedNegationBottomUpEngine());
+        }
+
+    }
+
+    public static class MyConjunctiveQueryTests extends ConjunctiveQueryTests {
+
+        public MyConjunctiveQueryTests() {
+            super(() -> new ConcurrentStratifiedNegationBottomUpEngine());
+        }
+
+    }
 }

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/ConjunctiveQueryTests.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/ConjunctiveQueryTests.java
@@ -1,4 +1,4 @@
-package edu.harvard.seas.pl.abcdatalog.engine.testing;
+package edu.harvard.seas.pl.abcdatalog.engine;
 
 /*-
  * #%L
@@ -46,7 +46,6 @@ import java.util.function.Supplier;
 import org.junit.Test;
 
 import edu.harvard.seas.pl.abcdatalog.ast.PositiveAtom;
-import edu.harvard.seas.pl.abcdatalog.engine.DatalogEngine;
 import edu.harvard.seas.pl.abcdatalog.parser.DatalogParseException;
 import edu.harvard.seas.pl.abcdatalog.parser.DatalogParser;
 import edu.harvard.seas.pl.abcdatalog.parser.DatalogTokenizer;

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/CoreTests.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/CoreTests.java
@@ -1,4 +1,4 @@
-package edu.harvard.seas.pl.abcdatalog.engine.testing;
+package edu.harvard.seas.pl.abcdatalog.engine;
 
 /*-
  * #%L
@@ -43,7 +43,6 @@ import org.junit.Test;
 
 import edu.harvard.seas.pl.abcdatalog.ast.PositiveAtom;
 import edu.harvard.seas.pl.abcdatalog.ast.validation.DatalogValidationException;
-import edu.harvard.seas.pl.abcdatalog.engine.DatalogEngine;
 
 public abstract class CoreTests extends AbstractTests {
 	

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/ExplicitUnificationTests.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/ExplicitUnificationTests.java
@@ -1,4 +1,4 @@
-package edu.harvard.seas.pl.abcdatalog.engine.testing;
+package edu.harvard.seas.pl.abcdatalog.engine;
 
 /*-
  * #%L
@@ -43,9 +43,8 @@ import org.junit.Test;
 
 import edu.harvard.seas.pl.abcdatalog.ast.PositiveAtom;
 import edu.harvard.seas.pl.abcdatalog.ast.validation.DatalogValidationException;
-import edu.harvard.seas.pl.abcdatalog.engine.DatalogEngine;
 
-public class ExplicitUnificationTests extends AbstractTests {
+public abstract class ExplicitUnificationTests extends AbstractTests {
 
 	public ExplicitUnificationTests(Supplier<DatalogEngine> engineFactory) {
 		super(engineFactory);

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/IterativeQsqEngineTest.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/IterativeQsqEngineTest.java
@@ -1,4 +1,4 @@
-package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
+package edu.harvard.seas.pl.abcdatalog.engine;
 
 /*-
  * #%L
@@ -8,18 +8,18 @@ package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
  * %%
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the President and Fellows of Harvard College nor the names of its contributors
  *    may be used to endorse or promote products derived from this software without
  *    specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -33,19 +33,30 @@ package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
  * #L%
  */
 
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.BottomUpEngineFrame;
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.EvalManager;
+import edu.harvard.seas.pl.abcdatalog.engine.topdown.IterativeQsqEngine;
 
-/**
- * A concurrent bottom-up Datalog engine that employs a saturation algorithm
- * similar to semi-naive evaluation. It supports explicit unification.
- *
- */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        IterativeQsqEngineTest.MyCoreTests.class,
+        IterativeQsqEngineTest.MyConjunctiveQueryTests.class
+})
+public class IterativeQsqEngineTest {
+    public static class MyCoreTests extends CoreTests {
 
-public class ConcurrentBottomUpEngine extends BottomUpEngineFrame<EvalManager> {
+        public MyCoreTests() {
+            super(() -> new IterativeQsqEngine());
+        }
 
-	public ConcurrentBottomUpEngine() {
-		super(new BottomUpEvalManager());
-	}
+    }
+
+    public static class MyConjunctiveQueryTests extends ConjunctiveQueryTests {
+
+        public MyConjunctiveQueryTests() {
+            super(() -> new IterativeQsqEngine());
+        }
+
+    }
 }

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/MstEngineTest.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/MstEngineTest.java
@@ -1,4 +1,4 @@
-package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
+package edu.harvard.seas.pl.abcdatalog.engine;
 
 /*-
  * #%L
@@ -8,18 +8,18 @@ package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
  * %%
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the President and Fellows of Harvard College nor the names of its contributors
  *    may be used to endorse or promote products derived from this software without
  *    specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -33,19 +33,30 @@ package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
  * #L%
  */
 
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.BottomUpEngineFrame;
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.EvalManager;
+import edu.harvard.seas.pl.abcdatalog.engine.topdown.MstEngine;
 
-/**
- * A concurrent bottom-up Datalog engine that employs a saturation algorithm
- * similar to semi-naive evaluation. It supports explicit unification.
- *
- */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        MstEngineTest.MyCoreTests.class,
+        MstEngineTest.MyConjunctiveQueryTests.class
+})
+public class MstEngineTest {
+    public static class MyCoreTests extends CoreTests {
 
-public class ConcurrentBottomUpEngine extends BottomUpEngineFrame<EvalManager> {
+        public MyCoreTests() {
+            super(() -> new MstEngine());
+        }
 
-	public ConcurrentBottomUpEngine() {
-		super(new BottomUpEvalManager());
-	}
+    }
+
+    public static class MyConjunctiveQueryTests extends ConjunctiveQueryTests {
+
+        public MyConjunctiveQueryTests() {
+            super(() -> new MstEngine());
+        }
+
+    }
 }

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/RecursiveQsqEngineTest.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/RecursiveQsqEngineTest.java
@@ -1,4 +1,4 @@
-package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
+package edu.harvard.seas.pl.abcdatalog.engine;
 
 /*-
  * #%L
@@ -8,18 +8,18 @@ package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
  * %%
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the President and Fellows of Harvard College nor the names of its contributors
  *    may be used to endorse or promote products derived from this software without
  *    specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -33,19 +33,30 @@ package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
  * #L%
  */
 
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.BottomUpEngineFrame;
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.EvalManager;
+import edu.harvard.seas.pl.abcdatalog.engine.topdown.RecursiveQsqEngine;
 
-/**
- * A concurrent bottom-up Datalog engine that employs a saturation algorithm
- * similar to semi-naive evaluation. It supports explicit unification.
- *
- */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        RecursiveQsqEngineTest.MyCoreTests.class,
+        RecursiveQsqEngineTest.MyConjunctiveQueryTests.class
+})
+public class RecursiveQsqEngineTest {
+    public static class MyCoreTests extends CoreTests {
 
-public class ConcurrentBottomUpEngine extends BottomUpEngineFrame<EvalManager> {
+        public MyCoreTests() {
+            super(() -> new RecursiveQsqEngine());
+        }
 
-	public ConcurrentBottomUpEngine() {
-		super(new BottomUpEvalManager());
-	}
+    }
+
+    public static class MyConjunctiveQueryTests extends ConjunctiveQueryTests {
+
+        public MyConjunctiveQueryTests() {
+            super(() -> new RecursiveQsqEngine());
+        }
+
+    }
 }

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/RunAllTests.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/RunAllTests.java
@@ -1,4 +1,4 @@
-package edu.harvard.seas.pl.abcdatalog.engine.testing;
+package edu.harvard.seas.pl.abcdatalog.engine;
 
 /*-
  * #%L
@@ -8,18 +8,18 @@ package edu.harvard.seas.pl.abcdatalog.engine.testing;
  * %%
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the President and Fellows of Harvard College nor the names of its contributors
  *    may be used to endorse or promote products derived from this software without
  *    specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -36,28 +36,18 @@ package edu.harvard.seas.pl.abcdatalog.engine.testing;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent.ConcurrentBottomUpEngine;
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent.ConcurrentChunkedBottomUpEngine;
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent.ConcurrentStratifiedNegationBottomUpEngine;
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.sequential.SemiNaiveEngine;
-import edu.harvard.seas.pl.abcdatalog.engine.topdown.IterativeQsqEngine;
-import edu.harvard.seas.pl.abcdatalog.engine.topdown.MstEngine;
-import edu.harvard.seas.pl.abcdatalog.engine.topdown.RecursiveQsqEngine;
-
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-	ConcurrentBottomUpEngine.class,
-	ConcurrentChunkedBottomUpEngine.class,
-	ConcurrentStratifiedNegationBottomUpEngine.class,
-	SemiNaiveEngine.class,
-	RecursiveQsqEngine.class,
-	IterativeQsqEngine.class,
-	MstEngine.class
+     ConcurrentBottomUpEngineTest.class,
+     ConcurrentChunkedBottomUpEngineTest.class,
+     ConcurrentStratifiedNegationBottomUpEngineTest.class,
+     SemiNaiveEngineTest.class,
+     RecursiveQsqEngineTest.class,
+     IterativeQsqEngineTest.class,
+     MstEngineTest.class
 })
 public class RunAllTests {
+    public RunAllTests() {
 
-	public RunAllTests() {
-		
-	}
-
+    }
 }

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/RunAllTests.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/RunAllTests.java
@@ -1,0 +1,63 @@
+package edu.harvard.seas.pl.abcdatalog.engine.testing;
+
+/*-
+ * #%L
+ * AbcDatalog
+ * %%
+ * Copyright (C) 2016 - 2021 President and Fellows of Harvard College
+ * %%
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * 3. Neither the name of the President and Fellows of Harvard College nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent.ConcurrentBottomUpEngine;
+import edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent.ConcurrentChunkedBottomUpEngine;
+import edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent.ConcurrentStratifiedNegationBottomUpEngine;
+import edu.harvard.seas.pl.abcdatalog.engine.bottomup.sequential.SemiNaiveEngine;
+import edu.harvard.seas.pl.abcdatalog.engine.topdown.IterativeQsqEngine;
+import edu.harvard.seas.pl.abcdatalog.engine.topdown.MstEngine;
+import edu.harvard.seas.pl.abcdatalog.engine.topdown.RecursiveQsqEngine;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+	ConcurrentBottomUpEngine.class,
+	ConcurrentChunkedBottomUpEngine.class,
+	ConcurrentStratifiedNegationBottomUpEngine.class,
+	SemiNaiveEngine.class,
+	RecursiveQsqEngine.class,
+	IterativeQsqEngine.class,
+	MstEngine.class
+})
+public class RunAllTests {
+
+	public RunAllTests() {
+		
+	}
+
+}

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/SemiNaiveEngineTest.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/SemiNaiveEngineTest.java
@@ -1,9 +1,4 @@
-/**
- * This package contains classes for testing the correctness of an
- * implementation of {@link edu.harvard.seas.pl.abcdatalog.engine}. Different
- * classes test different language features.
- */
-package edu.harvard.seas.pl.abcdatalog.engine.testing;
+package edu.harvard.seas.pl.abcdatalog.engine;
 
 /*-
  * #%L
@@ -13,18 +8,18 @@ package edu.harvard.seas.pl.abcdatalog.engine.testing;
  * %%
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice, this
  *    list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * 3. Neither the name of the President and Fellows of Harvard College nor the names of its contributors
  *    may be used to endorse or promote products derived from this software without
  *    specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -37,3 +32,49 @@ package edu.harvard.seas.pl.abcdatalog.engine.testing;
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import edu.harvard.seas.pl.abcdatalog.engine.bottomup.sequential.SemiNaiveEngine;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        SemiNaiveEngineTest.MyCoreTests.class,
+        SemiNaiveEngineTest.MyUnificationTests.class,
+        SemiNaiveEngineTest.MyNegationTests.class,
+        SemiNaiveEngineTest.MyConjunctiveQueryTests.class
+})
+public class SemiNaiveEngineTest {
+    public static class MyCoreTests extends CoreTests {
+
+        public MyCoreTests() {
+            super(() -> new SemiNaiveEngine(true));
+        }
+
+    }
+
+    public static class MyUnificationTests extends ExplicitUnificationTests {
+
+        public MyUnificationTests() {
+            super(() -> new SemiNaiveEngine(true));
+        }
+
+    }
+
+    public static class MyNegationTests extends StratifiedNegationTests {
+
+        public MyNegationTests() {
+            super(() -> new SemiNaiveEngine(true));
+        }
+
+    }
+
+    public static class MyConjunctiveQueryTests extends ConjunctiveQueryTests {
+
+        public MyConjunctiveQueryTests() {
+            super(() -> new SemiNaiveEngine(true));
+        }
+
+    }
+}

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/StratifiedNegationTests.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/StratifiedNegationTests.java
@@ -1,4 +1,4 @@
-package edu.harvard.seas.pl.abcdatalog.engine.testing;
+package edu.harvard.seas.pl.abcdatalog.engine;
 
 /*-
  * #%L
@@ -44,7 +44,6 @@ import org.junit.Test;
 
 import edu.harvard.seas.pl.abcdatalog.ast.PositiveAtom;
 import edu.harvard.seas.pl.abcdatalog.ast.validation.DatalogValidationException;
-import edu.harvard.seas.pl.abcdatalog.engine.DatalogEngine;
 
 public abstract class StratifiedNegationTests extends AbstractTests {
 

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/package-info.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/package-info.java
@@ -1,4 +1,9 @@
-package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
+/**
+ * This package contains classes for testing the correctness of an
+ * implementation of {@link edu.harvard.seas.pl.abcdatalog.engine}. Different
+ * classes test different language features.
+ */
+package edu.harvard.seas.pl.abcdatalog.engine;
 
 /*-
  * #%L
@@ -32,20 +37,3 @@ package edu.harvard.seas.pl.abcdatalog.engine.bottomup.concurrent;
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-
-
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.BottomUpEngineFrame;
-import edu.harvard.seas.pl.abcdatalog.engine.bottomup.EvalManager;
-
-/**
- * A concurrent bottom-up Datalog engine that employs a saturation algorithm
- * similar to semi-naive evaluation. It supports explicit unification.
- *
- */
-
-public class ConcurrentBottomUpEngine extends BottomUpEngineFrame<EvalManager> {
-
-	public ConcurrentBottomUpEngine() {
-		super(new BottomUpEvalManager());
-	}
-}


### PR DESCRIPTION
Moves the existing unit tests into a directory so that they can be run with `mvn test`. (see #12)
This also refactors testing code out of the engine classes.
