### PR TITLE
Release on Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,35 @@ subdirectory.
 # Requirements
 
 * Java 8+
-* Maven (v3.6.3 is known to work); necessary only for compilation
+* Maven (v3.6.3 is known to work); not necessary for running the pre-built JAR
 
-# Compilation
+# Setup
+
+## Pre-Built JAR
 
 A pre-built JAR can be found on the
-[Releases](https://github.com/HarvardPL/AbcDatalog/releases) section of GitHub.
+[Releases](https://github.com/HarvardPL/AbcDatalog/releases) section of the GitHub repository.
+
+## Maven Central
+
+AbcDatalog is released on [Maven Central](https://central.sonatype.com/artifact/io.github.harvardpl/AbcDatalog)
+and can be easily added as a library to another Maven project by including a
+snippet like this in that project's `pom.xml` file:
+
+```
+<dependency>
+    <groupId>io.github.harvardpl</groupId>
+    <artifactId>AbcDatalog</artifactId>
+    <version>[X.Y.Z]</version>
+</dependency>
+```
+
+Replace `[X.Y.Z]` with the most recent AbcDatalog version.
+
+## Compilation
 
 If you desire, you can compile the source code into a JAR using Maven. From
-this directory, run `mvn package` to build the archive
+the project root directory, run `mvn package` to build the archive
 `target/AbcDatalog-[X.Y.Z]-jar-with-dependencies.jar` (where `[X.Y.Z]` is the
 version number).
 

--- a/make_release.sh
+++ b/make_release.sh
@@ -16,7 +16,7 @@ mvn license:update-file-header
 # Make sure code is formatted consistently
 mvn com.spotify.fmt:fmt-maven-plugin:format
 # Generate Javadocs
-mvn javadoc:javadoc
+mvn javadoc:javadoc -Prelease
 git stash
 
 # Update the Javadocs on the website
@@ -29,3 +29,11 @@ git push
 
 git checkout master
 git stash pop
+
+# To upload the new release to Maven Central, run:
+#
+# mvn clean deploy -Prelease
+#
+# (This assumes you have a settings.xml file with the GPG passphrase and a
+# Sonatype token.) Once the package is validated, you can publish it using the
+# interface on <https://central.sonatype.org/>.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>io.github.harvardpl</groupId>
 	<artifactId>AbcDatalog</artifactId>
-	<version>0.7.0</version>
+	<version>0.7.1</version>
 	<packaging>jar</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>
@@ -14,8 +14,8 @@
 
 	<licenses>
 		<license>
-			<name>The Apache License, Version 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<name>The 3-Clause BSD License</name>
+			<url>https://opensource.org/license/bsd-3-clause</url>
 		</license>
 	</licenses>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,15 +2,42 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>edu.harvard.seas.pl</groupId>
+
+	<groupId>io.github.harvardpl</groupId>
 	<artifactId>AbcDatalog</artifactId>
 	<version>0.7.0</version>
-	<name>AbcDatalog</name>
+	<packaging>jar</packaging>
+
+	<name>${project.groupId}:${project.artifactId}</name>
+	<description>An implementation of the logic programming language Datalog.</description>
+	<url>https://harvardpl.github.io/AbcDatalog/</url>
+
+	<licenses>
+		<license>
+			<name>The Apache License, Version 2.0</name>
+			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+		</license>
+	</licenses>
+
+	<developers>
+		<developer>
+			<name>Aaron Bembenek</name>
+			<email>aaron.bembenek@gmail.com</email>
+		</developer>
+	</developers>
+
+	<scm>
+		<connection>scm:git:git://github.com/HarvardPL/AbcDatalog.git</connection>
+		<developerConnection>scm:git:ssh://github.com:HarvardPL/AbcDatalog.git</developerConnection>
+		<url>https://github.com/HarvardPL/AbcDatalog/tree/master/</url>
+	</scm>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -23,6 +50,7 @@
 			<version>3.1.1</version>
 		</dependency>
 	</dependencies>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -63,14 +91,6 @@
 				</configuration>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.3.0</version>
-				<configuration>
-					<doclint>none</doclint>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>com.spotify.fmt</groupId>
 				<artifactId>fmt-maven-plugin</artifactId>
 				<version>2.21.1</version>
@@ -82,6 +102,74 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.sonatype.central</groupId>
+				<artifactId>central-publishing-maven-plugin</artifactId>
+				<version>0.6.0</version>
+				<extensions>true</extensions>
+				<configuration>
+					<publishingServerId>central</publishingServerId>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>2.2.1</version>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar-no-fork</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>3.3.0</version>
+						<configuration>
+							<doclint>none</doclint>
+						</configuration>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.5</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+								<configuration>
+									<gpgArguments>
+										<arg>--pinentry-mode</arg>
+										<arg>loopback</arg>
+									</gpgArguments>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
Publish AbcDatalog releases on Maven Central so that it is easy to include AbcDatalog as a library in other Maven projects.

Fixes #23 