### PR TITLE
Fix bug in bound variables check; add regression tests

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/abcdatalog/ast/validation/DatalogValidator.java
+++ b/src/main/java/edu/harvard/seas/pl/abcdatalog/ast/validation/DatalogValidator.java
@@ -216,8 +216,16 @@ public class DatalogValidator {
       }
     }
 
+    for (Variable v : new HashSet<>(boundVars)) {
+      Term t = subst.get(v);
+      if (t instanceof Variable) {
+        boundVars.add((Variable) t);
+      }
+    }
+
     for (Variable x : possiblyUnboundVars) {
-      if (!boundVars.contains(x) && !(subst.get(x) instanceof Constant)) {
+      Term t;
+      if (!boundVars.contains(x) && !((t = subst.get(x)) instanceof Constant) && !(boundVars.contains(t))) {
         throw new DatalogValidationException(
             "Every variable in a rule must be bound, but "
                 + x

--- a/src/main/java/edu/harvard/seas/pl/abcdatalog/ast/validation/DatalogValidator.java
+++ b/src/main/java/edu/harvard/seas/pl/abcdatalog/ast/validation/DatalogValidator.java
@@ -225,7 +225,9 @@ public class DatalogValidator {
 
     for (Variable x : possiblyUnboundVars) {
       Term t;
-      if (!boundVars.contains(x) && !((t = subst.get(x)) instanceof Constant) && !(boundVars.contains(t))) {
+      if (!boundVars.contains(x)
+          && !((t = subst.get(x)) instanceof Constant)
+          && !(boundVars.contains(t))) {
         throw new DatalogValidationException(
             "Every variable in a rule must be bound, but "
                 + x

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/ExplicitUnificationTests.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/ExplicitUnificationTests.java
@@ -152,12 +152,12 @@ public abstract class ExplicitUnificationTests extends AbstractTests {
   }
 
   @Test
-  public void testVariablesBoundByUnifiers1() {
-    initEngine("p(X, Y) :- q(Z, W), X = Z, W = Y.");
+  public void testVariablesBoundByUnifiers1() throws DatalogValidationException {
+    test("p(X, Y) :- q(Z, W), X = Z, W = Y. q(a, b).", "p(a, b)?", "p(a, b).");
   }
 
   @Test
-  public void testVariablesBoundByUnifiers2() {
-    initEngine("p(X, Y) :- q(Z, W), Z = A, B = W, X = A, B = Y.");
+  public void testVariablesBoundByUnifiers2() throws DatalogValidationException {
+    test("p(X, Y) :- q(Z, W), Z = A, B = W, X = A, B = Y. q(a, b).", "p(a, b)?", "p(a, b).");
   }
 }

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/ExplicitUnificationTests.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/engine/ExplicitUnificationTests.java
@@ -150,4 +150,14 @@ public abstract class ExplicitUnificationTests extends AbstractTests {
     test("p(X) :- q(X), Y!=_. q(a).", "p(X)?", "");
     throw new DatalogValidationException();
   }
+
+  @Test
+  public void testVariablesBoundByUnifiers1() {
+    initEngine("p(X, Y) :- q(Z, W), X = Z, W = Y.");
+  }
+
+  @Test
+  public void testVariablesBoundByUnifiers2() {
+    initEngine("p(X, Y) :- q(Z, W), Z = A, B = W, X = A, B = Y.");
+  }
 }


### PR DESCRIPTION
The current check only works reliably when all variables are either bound or unifies with a constant, but it sometimes fails to realize that a variable is unified via binary unifiers to a bound variable.

Sometimes a possibly unbound variable ends up being the representative for the set of variables that it unifies with, in which case `subst.get()` just returns the possibly unbound variable.

The solution is to 1) expand the set of known bound variables to include all variables in the image of the derived substitution, and 2) apply the substitution to a possibly unbound variable and check if the result is bound if the other checks fail.

There may be a more clever way of doing this which I haven't realized.