### PR TITLE
Possibly an optimization of concurrent fact indexer

### DIFF
--- a/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/bottomup/concurrent/StratifiedNegationEvalManager.java
+++ b/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/bottomup/concurrent/StratifiedNegationEvalManager.java
@@ -83,10 +83,10 @@ public class StratifiedNegationEvalManager implements EvalManager {
 
   private final ConcurrentFactIndexer<ConcurrentLinkedBag<PositiveAtom>> facts =
       new ConcurrentFactIndexer<>(
-          () -> new ConcurrentLinkedBag<>(),
-          (bag, atom) -> bag.add(atom),
-          () -> ConcurrentLinkedBag.emptyBag(),
-          (bag) -> bag.size());
+          ConcurrentLinkedBag::new,
+          ConcurrentLinkedBag::add,
+          ConcurrentLinkedBag::emptyBag,
+          ConcurrentLinkedBag::size);
   private final ConcurrentFactTrie trie = new ConcurrentFactTrie();
 
   private final Map<PredicateSym, Set<Integer>> relevantStrataByPred = new HashMap<>();

--- a/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/bottomup/concurrent/StratifiedNegationEvalManager.java
+++ b/src/main/java/edu/harvard/seas/pl/abcdatalog/engine/bottomup/concurrent/StratifiedNegationEvalManager.java
@@ -85,7 +85,8 @@ public class StratifiedNegationEvalManager implements EvalManager {
       new ConcurrentFactIndexer<>(
           () -> new ConcurrentLinkedBag<>(),
           (bag, atom) -> bag.add(atom),
-          () -> ConcurrentLinkedBag.emptyBag());
+          () -> ConcurrentLinkedBag.emptyBag(),
+          (bag) -> bag.size());
   private final ConcurrentFactTrie trie = new ConcurrentFactTrie();
 
   private final Map<PredicateSym, Set<Integer>> relevantStrataByPred = new HashMap<>();

--- a/src/main/java/edu/harvard/seas/pl/abcdatalog/util/datastructures/FactIndexerFactory.java
+++ b/src/main/java/edu/harvard/seas/pl/abcdatalog/util/datastructures/FactIndexerFactory.java
@@ -51,7 +51,7 @@ public final class FactIndexerFactory {
    */
   public static ConcurrentFactIndexer<Set<PositiveAtom>> createConcurrentSetFactIndexer() {
     return new ConcurrentFactIndexer<>(
-        () -> Utilities.createConcurrentSet(), (set, fact) -> set.add(fact));
+        () -> Utilities.createConcurrentSet(), (set, fact) -> set.add(fact), (set) -> set.size());
   }
 
   /**
@@ -61,6 +61,6 @@ public final class FactIndexerFactory {
    */
   public static ConcurrentFactIndexer<Queue<PositiveAtom>> createConcurrentQueueFactIndexer() {
     return new ConcurrentFactIndexer<>(
-        () -> new ConcurrentLinkedQueue<>(), (queue, fact) -> queue.add(fact));
+        () -> new ConcurrentLinkedQueue<>(), (queue, fact) -> queue.add(fact), (queue) -> queue.size());
   }
 }

--- a/src/main/java/edu/harvard/seas/pl/abcdatalog/util/datastructures/FactIndexerFactory.java
+++ b/src/main/java/edu/harvard/seas/pl/abcdatalog/util/datastructures/FactIndexerFactory.java
@@ -51,7 +51,7 @@ public final class FactIndexerFactory {
    */
   public static ConcurrentFactIndexer<Set<PositiveAtom>> createConcurrentSetFactIndexer() {
     return new ConcurrentFactIndexer<>(
-        () -> Utilities.createConcurrentSet(), (set, fact) -> set.add(fact), (set) -> set.size());
+        Utilities::createConcurrentSet, Set::add, Set::size);
   }
 
   /**
@@ -61,6 +61,6 @@ public final class FactIndexerFactory {
    */
   public static ConcurrentFactIndexer<Queue<PositiveAtom>> createConcurrentQueueFactIndexer() {
     return new ConcurrentFactIndexer<>(
-        () -> new ConcurrentLinkedQueue<>(), (queue, fact) -> queue.add(fact), (queue) -> queue.size());
+        ConcurrentLinkedQueue::new, Queue::add, Queue::size);
   }
 }

--- a/src/test/java/edu/harvard/seas/pl/abcdatalog/util/datastructures/FactIndexerTest.java
+++ b/src/test/java/edu/harvard/seas/pl/abcdatalog/util/datastructures/FactIndexerTest.java
@@ -1,0 +1,47 @@
+package edu.harvard.seas.pl.abcdatalog.util.datastructures;
+
+import edu.harvard.seas.pl.abcdatalog.ast.*;
+import edu.harvard.seas.pl.abcdatalog.engine.AbstractTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import java.util.function.Supplier;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+  FactIndexerTest.SetTests.class,
+  FactIndexerTest.ConcurrentLinkedBagTests.class
+})
+public class FactIndexerTest {
+    public static class SetTests extends AbstractFactIndexerTests {
+        public SetTests() { super(FactIndexerFactory::createConcurrentSetFactIndexer); }
+    }
+
+    public static class ConcurrentLinkedBagTests extends AbstractFactIndexerTests {
+        public ConcurrentLinkedBagTests() { super(FactIndexerFactory::createConcurrentQueueFactIndexer); }
+    }
+
+    public static abstract class AbstractFactIndexerTests extends AbstractTests {
+        private final Supplier<FactIndexer> factIndexerFactory;
+
+        public AbstractFactIndexerTests(Supplier<FactIndexer> factIndexerFactory) {
+            super(() -> { throw new Error("Tests do not use engine="); });
+            this.factIndexerFactory = factIndexerFactory;
+        }
+
+        @Test
+        public void testSmallestFactSetIsReturnedFromFineIndex() {
+            FactIndexer indexer = factIndexerFactory.get();
+            indexer.addAll(parseFacts("f(a,x,b). f(b,x,b). f(c,x1,b). f(c,x2,b). f(c,x,d)."));
+
+            Iterable<PositiveAtom> result = indexer.indexInto(parseQuery("f(c,_,d)?"));
+            int size = 0;
+            for (PositiveAtom ignored : result) {
+                ++size;
+            }
+            Assert.assertEquals(1, size);
+        }
+    }
+}


### PR DESCRIPTION
I am using your excellent and readable implementation to learn about Datalog evaluation techniques and was a bit puzzled by the fact indexer which I think can be optimized to avoid hitting some worst-case edge cases. This is just a suggestion of course :).

The concurrent fact indexer maintains a coarse and fine index of
facts, where the coarse index is on the predicate symbol and the fine
index is on the predicate symbol, argument index and constant at that
argument. The fact indexer returns an overapproximation of the set of
facts that might match the input query but tries to minimize the
returned fact set using a heuristic which picks from the fine index
the fact set maintained at the argument position for which the most
distinct constants have been seen so far. Under the assumption that
the fact sets are roughly of equal size for each constant this is a
sound strategy, but it is easy to imagine worst cases where fact sets
that are much too large are returned. E.g. consider the facts

```
f(a, x, b).
f(b, x, b).
f(c, x1, b).
f(c, x2, b).
...
f(c, x10000, b).
f(c, x, d).
```

and the query `f(c, _, d)?`

Two fine indexes will be considered as candidates; the first and the
third. The first index has three distinct constants and the third has
only two. The candidate fact set returned is thus the 10,001 element
set

`{ f(c, x1, b), ..., f(c, x10000, b), f(c, x, d) }`

rather than the singleton set

`{ f(c, x, d) }`

The fact indexer cannot evaluate the size of the underlying container
since it has to work for all `Iterable` containers, including
`ConcurrentLinkedBag` which cannot implement the `Container` interface for
efficiency reasons. It is however quite easy to add a size method to
this collection type and pass it as a lambda to the fact indexer. The
fact indexer can then just pick the smallest set from the fine index
instead of relying on a heuristic.